### PR TITLE
Support Humble

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ find_package(geometry_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 
 find_package(rosidl_default_generators REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
@@ -108,6 +110,8 @@ ament_target_dependencies(swd_diff_drive_controller
   tf2
   tf2_msgs
   tf2_ros
+  lifecycle_msgs
+  rclcpp_lifecycle
 )
 
 rosidl_target_interfaces(swd_diff_drive_controller

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ sudo apt update && sudo apt install swd-services ros-foxy-swd-ros2-controllers
 sudo apt update && sudo apt install swd-services ros-galactic-swd-ros2-controllers
 ```
 
+### Humble
+
+```shell
+sudo apt update && sudo apt install swd-services ros-humble-swd-ros2-controllers dbus-x11
+```
+
 ### Compiling from source
 
 To compile the package, make sure you have added the ez-Wheel repository to your `/etc/apt/sources.list` as specified above.


### PR DESCRIPTION
I would like to support ROS2 Humble with swd_ros2_controllers.
`dbus-x11` must be installed to launch dbus service and `lefecycle_msgs` and `rclcpp_lifecycle` must be added as dependency to build source code.