### PR TITLE
The param name of left config file and right config file is not same as DiffDriveParameters.cpp

### DIFF
--- a/launch/swd_diff_drive_controller.launch.py
+++ b/launch/swd_diff_drive_controller.launch.py
@@ -46,8 +46,8 @@ def generate_launch_description():
             parameters=[
                         {'use_sim_time': LaunchConfiguration('use_sim_time')},
                         {"baseline_m": LaunchConfiguration('baseline_m')},
-                        {"left_swd_config_file": "/opt/ezw/usr/etc/ezw-smc-core/swd_left_config.ini"},
-                        {"right_swd_config_file": "/opt/ezw/usr/etc/ezw-smc-core/swd_right_config.ini"},
+                        {"left_config_file": "/opt/ezw/usr/etc/ezw-smc-core/swd_left_config.ini"},
+                        {"right_config_file": "/opt/ezw/usr/etc/ezw-smc-core/swd_right_config.ini"},
                         {"pub_freq_hz": 20},
                         {"watchdog_receive_ms": 500},
                         {"base_frame": "base_link"},


### PR DESCRIPTION
The parameter names of left config file and right config file are defined in DiffDriveParameters.cpp as `left_config_file` and `right_config_file`.
However, the parameter names in swd_diff_drive_controller.launch.py are `left_swd_config_file` and `right_swd_config_file`.
Therefore, the default config file is always read when launch file is called.